### PR TITLE
Fix get_messages return

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,7 +52,7 @@ def get_messages(chat_id, limit=300):
     messages = db['messages']
     chat_messages = messages.find_one(chat_id=chat_id)
     if not chat_messages:
-        return chat_messages
+        return ''
 
     messages = read_messages(chat_messages['text'])
     text = '\n'.join(t[2] for t in messages)


### PR DESCRIPTION
If the messages table is empty the function **get_messages** will return a **None** value, which is a problem inside the **summarize** function because it's going to execute `summarizer.summarize('. .', None)` that throws a type error exception: `TypeError: expected string or bytes-like object`.